### PR TITLE
Fix crashed when using WebView got invalid info

### DIFF
--- a/app/src/main/java/com/qyinter/yuanshenlink/util/AccountUtil.kt
+++ b/app/src/main/java/com/qyinter/yuanshenlink/util/AccountUtil.kt
@@ -62,7 +62,8 @@ object AccountUtil {
                 .getAsJsonObject(JSON_DATA_ACCOUNT_INFO)    // account_info
         } catch (e: Exception) {
             return null
-        }
+        } ?: return null        // accountInfo may be a null here
+        
         return Account(
             accountInfo[JSON_DATA_ACCOUNT_INFO_ACCOUNT_ID].asString,
             accountInfo[JSON_DATA_ACCOUNT_INFO_WEB_LOGIN_TOKEN].asString


### PR DESCRIPTION
When WebView page does not get valid login cookie and press `DONE` button, the `accountInfo` will be null then crash.